### PR TITLE
QOL-9166 add URL to featured results

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -13,18 +13,6 @@
 #qg-content #qg-secondary-content .qg-aside h2 {
     display: none;
 }
-.qg-card__clickable .content:after {
-    bottom: 1.3rem;
-    position: absolute;
-    right: 1rem;
-    color: #212529;
-    font-size: 1.2rem;
-    content: "\f061";
-    font-family: FontAwesome;
-    text-rendering: auto;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-}
 .qg-filter-by-results {
     margin-bottom: 2rem;
 }

--- a/src/template/featured-results.ts
+++ b/src/template/featured-results.ts
@@ -4,12 +4,18 @@ export function featuredResultsTemplate (exhibits: any[]) {
   return html`<h2 class="search-results-summary">Featured results</h2>
     ${exhibits.map((item, index) => {
                 return html`
-                <!-- Exhibit item: ${item} -->
                     <article class="qg-card qg-card__light-theme qg-card__clickable">
                         <div class="content">
                             <div class="details">
-                                <h2 class="qg-card__title"><a href="https://find.search.qld.gov.au${item.linkUrl}" class="stretched-link">${item.titleHtml}</a></h2>
-                                <p>${item.descriptionHtml}</p>
+                                <h2 class="qg-card__title">
+                                    <a href="https://find.search.qld.gov.au${item.linkUrl}" class="stretched-link">${item.titleHtml}</a>
+                                </h2>
+                                <ul class="qg-search-results__results-list">
+                                    <li class="description">${item.descriptionHtml}</li>
+                                    <li class="meta">
+                                        <span class="qg-search-results__url">${item.displayUrl}</span>
+                                    </li>
+                                </ul>
                             </div>
                         </div>
                     </article>`

--- a/src/template/featured-results.ts
+++ b/src/template/featured-results.ts
@@ -10,12 +10,10 @@ export function featuredResultsTemplate (exhibits: any[]) {
                                 <h2 class="qg-card__title">
                                     <a href="https://find.search.qld.gov.au${item.linkUrl}" class="stretched-link">${item.titleHtml}</a>
                                 </h2>
-                                <ul class="qg-search-results__results-list">
-                                    <li class="description">${item.descriptionHtml}</li>
-                                    <li class="meta">
-                                        <span class="qg-search-results__url">${item.displayUrl}</span>
-                                    </li>
-                                </ul>
+                                <div class="qg-search-results__results-list">
+                                    <p class="description">${item.descriptionHtml}</p>
+                                    <p class="qg-search-results__url">${item.displayUrl}</p>
+                                </div>
                             </div>
                         </div>
                     </article>`

--- a/src/template/featured-results.ts
+++ b/src/template/featured-results.ts
@@ -4,6 +4,7 @@ export function featuredResultsTemplate (exhibits: any[]) {
   return html`<h2 class="search-results-summary">Featured results</h2>
     ${exhibits.map((item, index) => {
                 return html`
+                <!-- Exhibit item: ${item} -->
                     <article class="qg-card qg-card__light-theme qg-card__clickable">
                         <div class="content">
                             <div class="details">

--- a/src/template/main.ts
+++ b/src/template/main.ts
@@ -10,9 +10,7 @@ export function mainTemplate (response: Response, paramMap: ParamMap) {
   const { exhibits } = curator
 
   return html`
-    <!-- Exhibits: ${exhibits.keys} -->
         ${exhibits.length > 0 ? featuredResultsTemplate(exhibits) : ''}
-    <!-- Result packet: ${resultPacket.keys} -->
         ${searchResultsTemplate(resultPacket)}
         ${paginationTemplate(response, paramMap)}
     `

--- a/src/template/main.ts
+++ b/src/template/main.ts
@@ -10,9 +10,9 @@ export function mainTemplate (response: Response, paramMap: ParamMap) {
   const { exhibits } = curator
 
   return html`
-    <!-- Exhibits: ${exhibits} -->
+    <!-- Exhibits: ${exhibits.keys} -->
         ${exhibits.length > 0 ? featuredResultsTemplate(exhibits) : ''}
-    <!-- Result packet: ${resultPacket} -->
+    <!-- Result packet: ${resultPacket.keys} -->
         ${searchResultsTemplate(resultPacket)}
         ${paginationTemplate(response, paramMap)}
     `

--- a/src/template/main.ts
+++ b/src/template/main.ts
@@ -10,7 +10,9 @@ export function mainTemplate (response: Response, paramMap: ParamMap) {
   const { exhibits } = curator
 
   return html`
+    <!-- Exhibits: ${exhibits} -->
         ${exhibits.length > 0 ? featuredResultsTemplate(exhibits) : ''}
+    <!-- Result packet: ${resultPacket} -->
         ${searchResultsTemplate(resultPacket)}
         ${paginationTemplate(response, paramMap)}
     `


### PR DESCRIPTION
- Add the full URL to featured results, similarly to regular results.
- Drop the arrow from featured results as it's been judged unnecessary.

The file size and modified date are unfortunately not provided by Funnelback and therefore couldn't be included.