### PR TITLE
QOLDEV-504 Updatig search url and search collection

### DIFF
--- a/cypress/integration/search-page-uat.spec.js
+++ b/cypress/integration/search-page-uat.spec.js
@@ -1,5 +1,5 @@
 const ROOT_URL = 'http://localhost:1234'
-import { search_collection } from '../utils/constants'
+import { search_collection } from '../src/utils/constants'
 
 const wt = 500;
 function formatString(text) {

--- a/cypress/integration/search-page-uat.spec.js
+++ b/cypress/integration/search-page-uat.spec.js
@@ -1,4 +1,5 @@
 const ROOT_URL = 'http://localhost:1234'
+import { search_collection } from '../utils/constants'
 
 const wt = 500;
 function formatString(text) {
@@ -12,7 +13,7 @@ context('Search page', () => {
       .get('.qg-filter-by-results')
       .should('not.exist')
     // also if profile is 'qld', the filter should not appear
-    cy.visit(`${ROOT_URL}/?query=rego&num_ranks=10&tiers=off&collection=qld-gov&profile=qld`)
+    cy.visit(`${ROOT_URL}/?query=rego&num_ranks=10&tiers=off&collection=${search_collection}&profile=qld`)
     cy
       .get('.qg-filter-by-results')
       .should('not.exist')
@@ -20,7 +21,7 @@ context('Search page', () => {
 
   // scope is present with no profile
   it("Filter should appear if scope is present, but if its value is not 'qld.gov.au'", () => {
-    cy.visit(`${ROOT_URL}/?query=rego&num_ranks=10&tiers=off&collection=qld-gov&profile=qld&scope=tmr.qld.gov.au&collection=qld-gov`)
+    cy.visit(`${ROOT_URL}/?query=rego&num_ranks=10&tiers=off&collection=${search_collection}&profile=qld&scope=tmr.qld.gov.au&collection=${search_collection}`)
     cy
       .get('.qg-filter-by-results')
       .should('be.visible')
@@ -42,7 +43,7 @@ context('Search page', () => {
 
   // profile is present with no scope
   it('Filter should be visible if profile is present with no scope', () => {
-    cy.visit(`${ROOT_URL}/?query=rego&num_ranks=10&tiers=off&collection=qld-gov&profile=forgov&scope=&collection=qld-gov&filter=true`)
+    cy.visit(`${ROOT_URL}/?query=rego&num_ranks=10&tiers=off&collection=${search_collection}&profile=forgov&scope=&collection=${search_collection}&filter=true`)
     cy
       .get('.qg-filter-by-results')
       .should('be.visible')

--- a/src/index.html
+++ b/src/index.html
@@ -22,7 +22,7 @@
             <include src="./node_modules/web-template-release/template-cdn-ssi/assets/includes-cdn/header/mobile-menu-button.html"></include>
             <include src="./node_modules/web-template-release/template-cdn-ssi/assets/includes-cdn/header/coat-of-arms.html"></include>
             <include src="./node_modules/web-template-release/template-cdn-ssi/assets/includes-cdn/header/site-search.html"></include>
-            <form action="https://www.qld.gov.au/search" id="qg-global-search-form" role="search" class="qg-site-search__form qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&smeta_sfinder_sand=yes">
+            <form action="https://www.qld.gov.au/search" id="qg-global-search-form" role="search" class="qg-site-search__form qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://discover.search.qld.gov.au/s/suggest.json?collection=qgov~sp-qld&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://discover.search.qld.gov.au/s/search.json?collection=qgov~sp-qld&profile=qld&smeta_sfinder_sand=yes">
                 <div class="input-group">
                     <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
                     <input type="text" name="query" id="qg-search-query" class="form-control qg-search-site__input" autocomplete="off" placeholder="Search website" tabindex="0" aria-required="true" aria-expanded="false"/>
@@ -108,7 +108,7 @@
                 <!--parameters to display results on search page-->
                 <input type="hidden" name="num_ranks" value="10">
                 <input type="hidden" name="tiers" value="off">
-                <input type="hidden" name="collection" value="qld-gov">
+                <input type="hidden" name="collection" value="qgov~sp-qld">
                 <input type="hidden" name="profile" value="qld">
             </form>
         </div>

--- a/src/template/featured-results.ts
+++ b/src/template/featured-results.ts
@@ -1,4 +1,5 @@
 import { html } from 'lit-html'
+import { search_url } from '../utils/constants'
 
 export function featuredResultsTemplate (exhibits: any[]) {
   return html`<h2 class="search-results-summary">Featured results</h2>
@@ -8,7 +9,7 @@ export function featuredResultsTemplate (exhibits: any[]) {
                         <div class="content">
                             <div class="details">
                                 <h2 class="qg-card__title">
-                                    <a href="https://find.search.qld.gov.au${item.linkUrl}" class="stretched-link">${item.titleHtml}</a>
+                                    <a href="${search_url}${item.linkUrl}" class="stretched-link">${item.titleHtml}</a>
                                 </h2>
                                 <div class="qg-search-results__results-list">
                                     <p class="description">${item.descriptionHtml}</p>

--- a/src/template/search-form.ts
+++ b/src/template/search-form.ts
@@ -1,3 +1,5 @@
+import { search_url } from '../utils/constants'
+import { search_collection } from '../utils/constants'
 import { html, render } from 'lit-html'
 import { fetchData } from '../utils/fetchData'
 import { mainTemplate } from './main'
@@ -22,7 +24,7 @@ export function searchForm () {
       params.set('start_rank', '1')
       params.set('num_ranks', '10')
       params.set('tiers', 'off')
-      params.set('collection', 'qld-gov')
+      params.set('collection', 'qgov~sp-qld')
 
       // push history stack and fetch data
       setTimeout(function () {
@@ -64,7 +66,7 @@ export function searchForm () {
   }
 
   return html`
-        <form action="#" role="search" class="qg-site-search__form qg-site-search__component qg-search-form qg-site-search__multiple-forms" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&smeta_sfinder_sand=yes">
+        <form action="#" role="search" class="qg-site-search__form qg-site-search__component qg-search-form qg-site-search__multiple-forms" data-suggestions="${search_url}/s/suggest.json?collection=${search_collection}&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="${search_url}/s/search.json?collection=${search_collection}&profile=qld&smeta_sfinder_sand=yes">
                     <div class="input-group">
                         <label for="qg-search-query-sm" class="qg-visually-hidden">Search Queensland Government</label>
                         <input type="text" name="query" id="qg-search-query-sm"  class="form-control qg-search-site__input" autocomplete="off" placeholder="Search website" tabindex="0" aria-required="true" aria-expanded="false" value="${currUrlParameterMap.query}" @keydown="${onInputClick}" @click="${onInputClick}"/>

--- a/src/template/search-results.ts
+++ b/src/template/search-results.ts
@@ -1,3 +1,4 @@
+import { search_url } from '../utils/constants'
 import { html } from 'lit-html'
 import { formatNumber, formatSize, formatDate } from '../utils/formatContent'
 
@@ -13,7 +14,7 @@ export function searchResultsTemplate(resultPacket: { query: string; resultsSumm
             ${resultPacket.results.map((result: any) => html`
                 <li class="qg-search-results__results-list-item">
                     <h3>
-                        <a href="https://find.search.qld.gov.au${result.clickTrackingUrl}">${customizeTitle(result.title)}</a>
+                        <a href="${search_url}${result.clickTrackingUrl}">${customizeTitle(result.title)}</a>
                     </h3>
                     <ul class="qg-search-results__results-list">
                         <li class="description"> ${result.metaData.C}</li>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,1 +1,3 @@
-export const API_URL = 'https://find.search.qld.gov.au/s/search.json'
+export const API_URL = 'https://discover.search.qld.gov.au/s/search.json'
+export const search_url = 'https://discover.search.qld.gov.au'
+export const search_collection = 'qgov~sp-qld'


### PR DESCRIPTION
Defined constants for search_url and search_collection.
With Funnel upgrade search url needs to be updated from find.seach to discover.search.
qld-gov collection will be renamed to qgov~sp-qld. 