### PR TITLE
QOLDEV-504 Updating the structure for the results metadata

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,3 +19,6 @@ https://parceljs.org/
 
 Typescript
 https://www.typescriptlang.org/
+
+## Run locally
+Install Lit and Parcel JS. Then run `npm run build` to launch the global search on http://localhost:1234.

--- a/src/template/search-results.ts
+++ b/src/template/search-results.ts
@@ -17,7 +17,7 @@ export function searchResultsTemplate(resultPacket: { query: string; resultsSumm
                         <a href="${search_url}${result.clickTrackingUrl}">${customizeTitle(result.title)}</a>
                     </h3>
                     <ul class="qg-search-results__results-list">
-                        <li class="description"> ${result.listMetadata["C"]}</li>
+                        <li class="description">${Array.isArray(result.listMetadata.c) ? result.listMetadata.c[0] : result.summary}</li>
                         <li class="meta">
                             <span class="qg-search-results__url">${result.indexUrl}</span>
                             ${result.fileSize ? html`<span>&nbsp;-&nbsp;${formatSize(result.fileSize)}</span>` : ''}

--- a/src/template/search-results.ts
+++ b/src/template/search-results.ts
@@ -17,7 +17,7 @@ export function searchResultsTemplate(resultPacket: { query: string; resultsSumm
                         <a href="${search_url}${result.clickTrackingUrl}">${customizeTitle(result.title)}</a>
                     </h3>
                     <ul class="qg-search-results__results-list">
-                        <li class="description"> ${result.metaData.C}</li>
+                        <li class="description"> ${result.listMetadata["C"]}</li>
                         <li class="meta">
                             <span class="qg-search-results__url">${result.indexUrl}</span>
                             ${result.fileSize ? html`<span>&nbsp;-&nbsp;${formatSize(result.fileSize)}</span>` : ''}


### PR DESCRIPTION
Based on Squiz document, the results metadata is not an array anymore. It is a list instead.
https://docs.squiz.net/funnelback/docs/latest/build/results-pages/query-processing-configuration/response-metadata.html