### PR TITLE
Qoldev 504 total matching property

### DIFF
--- a/src/modules/SearchModule.ts
+++ b/src/modules/SearchModule.ts
@@ -50,8 +50,10 @@ export class SearchModule {
      * */
   processData () {
     this.fetchData().then(data => {
-      const { contextualNavigation, results } = data?.response?.resultPacket
-      if (results.length > 0) {
+      const contextualNavigation = data?.response?.resultPacket?.contextualNavigation
+      const totalMatching = data?.response?.resultPacket.resultsSummary?.totalMatching
+      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment
+      if (totalMatching > 0) {
         this.spinnerEl?.setAttribute('hidden', '')
         render(mainTemplate(data?.response, this.urlParameter), document.getElementById('qg-search-results__container')!)
         if (contextualNavigation) {

--- a/src/modules/SearchModule.ts
+++ b/src/modules/SearchModule.ts
@@ -51,7 +51,7 @@ export class SearchModule {
   processData () {
     this.fetchData().then(data => {
       const contextualNavigation = data?.response?.resultPacket?.contextualNavigation
-      const totalMatching = data?.response?.resultPacket.resultsSummary?.totalMatching
+      const totalMatching = data?.response?.resultPacket?.resultsSummary?.totalMatching
       // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment
       if (totalMatching > 0) {
         this.spinnerEl?.setAttribute('hidden', '')

--- a/src/template/pagination.ts
+++ b/src/template/pagination.ts
@@ -59,7 +59,7 @@ export function paginationTemplate (response: Response, paramMap: ParamMap) {
                 ${currUrlParameterMap.startRank > 1 ? html`<a class="page-link"  @click="${onPageClick}" href="${buildHref}&page=${currUrlParameterMap.activePage - 1}&start_rank=${currUrlParameterMap.startRank - 10}"><span aria-hidden="true">«</span> Previous</a>` : ''}
             </li>
             ${range(paginationStartValue(), paginationEndValue()).map(i => {
-                const addParam = buildHref + `&page=${i}&start_rank=${((currUrlParameterMap.numRanks || paginationOnPage) * (i - 1)) + 1}`
+                const addParam = buildHref + `&page=${i}&start_rank=${(paginationOnPage * (i - 1)) + 1}`
                 const determineActivePage = currUrlParameterMap.activePage === i ? 'active' : ''
                 return html`<li class="page-item ${determineActivePage}"><a class="page-link" @click="${onPageClick}"  href=${addParam}>${i}</a></li>`
             })}

--- a/src/template/related-search.ts
+++ b/src/template/related-search.ts
@@ -18,8 +18,9 @@ export function relatedResultsTemplate (contextualNavigation: { categories: any;
 
     // fetch the results
     fetchData(clickedHref).then(data => {
-      const { contextualNavigation, results } = data?.response?.resultPacket
-      if (results?.length) {
+      const contextualNavigation = data?.response?.resultPacket?.contextualNavigation
+      const totalMatching = data?.response?.resultPacket?.resultsSummary?.totalMatching
+      if (totalMatching > 0) {
         render(mainTemplate(data?.response, currUrlParameterMap), document.getElementById('qg-search-results__container') as HTMLBodyElement)
         render(relatedResultsTemplate(contextualNavigation), document.getElementById('related-search__tags')!)
       } else {

--- a/src/template/search-form.ts
+++ b/src/template/search-form.ts
@@ -30,8 +30,9 @@ export function searchForm () {
         params.set('query', currInputValue)
         history.pushState({}, '', `?${params.toString()}`)
         fetchData(params.toString()).then(data => {
-          const { contextualNavigation, results } = data?.response?.resultPacket
-          if (results?.length) {
+          const contextualNavigation = data?.response?.resultPacket?.contextualNavigation
+          const totalMatching = data?.response?.resultPacket?.resultsSummary?.totalMatching
+          if (totalMatching > 0) {
             render(mainTemplate(data?.response, currUrlParameterMap), document.getElementById('qg-search-results__container') as HTMLBodyElement)
             render(relatedResultsTemplate(contextualNavigation), document.getElementById('related-search__tags')!)
           } else {

--- a/src/types/url-parameters.ts
+++ b/src/types/url-parameters.ts
@@ -3,7 +3,6 @@ export interface ParamMap {
     profile: string
     label : string
     filter : string
-    numRanks : number
     startRank : number
     collection : string
     scope : string


### PR DESCRIPTION
- Replacing results.length parameter with totalMatching as results is sometimes empty
- Removing numRanks from ParamMap interface

Example
https://discover.search.qld.gov.au/s/search.json?query=seniors=off&query=seniors&num_ranks=0&profile=qld&scope=&collection=qgov~sp-search
