### PR TITLE
QOLSVC-4828 Removing second heading 'Related search'

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -49,3 +49,11 @@
         display: inherit;
     }
 }
+
+.related-search__container .related-search__tags {
+    border-top: 2px solid #000;
+    font-weight: 700;
+    margin-top: 1.5em;
+    padding-top: 0.8em;
+    padding-left: 1em;
+}

--- a/src/template/related-search.ts
+++ b/src/template/related-search.ts
@@ -34,8 +34,7 @@ export function relatedResultsTemplate (contextualNavigation: { categories: any;
     const { categories } = contextualNavigation
     for (let i = 0; i < categories.length; i++) {
       if (categories[i]?.name === 'topic') {
-        return html` <p class="related-search__title">Related search</p>
-        <section class="related-search__tags">
+        return html` <section class="related-search__tags">
             ${categories[i]?.clusters.map((item: any) =>
               html`<a @click="${(e: RelatedSearchClick) => onRelatedSearchClick(e)}" href="${item.href}&start_rank=1" class="qg-btn btn-outline-dark m-1">${item.query}</a>`
           )}


### PR DESCRIPTION
Removing 'Related search' heading as the search aside already has a title.
Adding css rules to add a separator.

**Before:**
![image](https://github.com/qld-gov-au/global-search/assets/126438691/fe61cbca-dbed-45e7-a9b6-f86eca5ca0df)

**After:**
![image](https://github.com/qld-gov-au/global-search/assets/126438691/0ecc41d0-7587-4211-93ac-44c418d38dfb)
